### PR TITLE
Scanning for multiple QR codes.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   "rules": {
     "comma-dangle": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "react/no-array-index-key": "off",
     "react/prop-types": "off",
     "semi": "off"
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,6 @@
   "rules": {
     "comma-dangle": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "react/no-array-index-key": "off",
     "react/prop-types": "off",
     "semi": "off"
   },

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -26,6 +26,6 @@ beforeAll(() => {
 test('renders title', () => {
   React.useState.mockImplementation(jest.requireActual('react').useState);
   render(<App />);
-  const titleElement = screen.getByText(/Health Cards/i);
+  const titleElement = screen.getByText(/SMART® Health Cards/i);
   expect(titleElement).toBeInTheDocument();
 });

--- a/src/components/HealthCardDisplay/HealthCardDisplay.js
+++ b/src/components/HealthCardDisplay/HealthCardDisplay.js
@@ -17,8 +17,8 @@ const useStyles = makeStyles({
 
 const HealthCardDisplay = () => {
   const classes = useStyles();
-  const { qrCode } = useQrDataContext();
-  const patientData = getPatientData(qrCode);
+  const { qrCodes } = useQrDataContext();
+  const patientData = getPatientData(qrCodes);
   const [tradenames, setTradenames] = useState({});
   const [cvxCodes, setCvxCodes] = useState({});
 

--- a/src/components/HealthCardDisplay/HealthCardDisplay.test.js
+++ b/src/components/HealthCardDisplay/HealthCardDisplay.test.js
@@ -119,15 +119,6 @@ const cvxCodes = `<CVXCodes>
 
 jest.mock('axios');
 
-const renderHealthCardDisplay = () => {
-  qrHelpers.getPatientData = jest.fn().mockReturnValue(patientData);
-  return render(
-    <QrDataContext.Provider value={{ qrCode: '', setQrCode: jest.fn() }}>
-      <HealthCardDisplay />
-    </QrDataContext.Provider>
-  );
-}
-
 beforeAll(() => {
   jest.spyOn(React, 'useEffect').mockImplementation((f) => f());
 });
@@ -135,6 +126,15 @@ beforeAll(() => {
 afterEach(() => {
   jest.spyOn(React, 'useEffect').mockImplementation((f) => f());
 });
+
+const renderHealthCardDisplay = () => {
+  qrHelpers.getPatientData = jest.fn().mockReturnValue(patientData);
+  return render(
+    <QrDataContext.Provider value={{ qrCodes: [], setQrCode: jest.fn() }}>
+      <HealthCardDisplay />
+    </QrDataContext.Provider>
+  );
+}
 
 test('renders health card', () => {
   renderHealthCardDisplay();

--- a/src/components/HealthCardVerify/HealthCardVerify.js
+++ b/src/components/HealthCardVerify/HealthCardVerify.js
@@ -17,9 +17,9 @@ const useStyles = makeStyles({
 
 const HealthCardVerify = () => {
   const classes = useStyles();
-  const { qrCode } = useQrDataContext();
-  const jws = getJws(qrCode);
-  const iss = getIssuer(qrCode);
+  const { qrCodes } = useQrDataContext();
+  const jws = getJws(qrCodes);
+  const iss = getIssuer(qrCodes);
   const [verified, setVerified] = useState();
   const [error, setError] = useState(null);
 

--- a/src/components/HealthCardVerify/HealthCardVerify.test.js
+++ b/src/components/HealthCardVerify/HealthCardVerify.test.js
@@ -42,7 +42,7 @@ const renderHealthCardVerify = ({ jwsValue = jws, issValue = iss }) => {
   qrHelpers.getJws = jest.fn().mockReturnValue(jwsValue);
   qrHelpers.getIssuer = jest.fn().mockReturnValue(issValue);
   return render(
-    <QrDataContext.Provider value={{ qrCode: '', setQrCode: jest.fn() }}>
+    <QrDataContext.Provider value={{ qrCodes: [], setQrCode: jest.fn() }}>
       <HealthCardVerify />
     </QrDataContext.Provider>
   );

--- a/src/components/IssuerVerify/IssuerVerify.js
+++ b/src/components/IssuerVerify/IssuerVerify.js
@@ -15,8 +15,8 @@ const useStyles = makeStyles({
 
 const IssuerVerify = () => {
   const classes = useStyles();
-  const { qrCode } = useQrDataContext();
-  const iss = getIssuer(qrCode);
+  const { qrCodes } = useQrDataContext();
+  const iss = getIssuer(qrCodes);
   const [issuerDirectories, setIssuerDirectories] = useState(null);
   const [verified, setVerified] = useState(null);
   const [errors, setErrors] = useState(null);

--- a/src/components/IssuerVerify/IssuerVerify.test.js
+++ b/src/components/IssuerVerify/IssuerVerify.test.js
@@ -38,7 +38,7 @@ afterEach(() => {
 const renderIssuerVerify = ({ issValue = iss }) => {
   qrHelpers.getIssuer = jest.fn().mockReturnValue(issValue);
   return render(
-    <QrDataContext.Provider value={{ qrCode: '', setQrCode: jest.fn() }}>
+    <QrDataContext.Provider value={{ qrCodes: [], setQrCode: jest.fn() }}>
       <IssuerVerify />
     </QrDataContext.Provider>
   );

--- a/src/components/QrDataProvider.js
+++ b/src/components/QrDataProvider.js
@@ -3,11 +3,11 @@ import React, { createContext, useContext, useState } from 'react';
 const QrDataContext = createContext();
 
 const QrDataProvider = ({ children }) => {
-  const [qrCode, setQrCode] = useState(null);
+  const [qrCodes, setQrCodes] = useState(null);
 
   return (
     <QrDataContext.Provider
-      value={{ qrCode, setQrCode }}
+      value={{ qrCodes, setQrCodes }}
     >
       {children}
     </QrDataContext.Provider>

--- a/src/components/QrScan/QrScan.js
+++ b/src/components/QrScan/QrScan.js
@@ -41,7 +41,7 @@ const healthCardPattern = /^shc:\/(?<multipleChunks>(?<chunkIndex>[0-9]+)\/(?<ch
 const QrScan = () => {
   const history = useHistory();
   const classes = useStyles();
-  const { setQrCode } = useQrDataContext();
+  const { setQrCodes } = useQrDataContext();
   const [scannedCodes, setScannedCodes] = useState([]);
 
   const handleScan = (data) => {
@@ -61,13 +61,13 @@ const QrScan = () => {
         }
 
         if (tempScannedCodes.every((code) => code)) {
-          setQrCode(data);
+          setQrCodes(tempScannedCodes);
           history.push('/display-results');
         }
 
         setScannedCodes(tempScannedCodes);
       } else {
-        setQrCode(data);
+        setQrCodes([data]);
         history.push('/display-results');
       }
     }

--- a/src/components/QrScan/QrScan.js
+++ b/src/components/QrScan/QrScan.js
@@ -91,7 +91,7 @@ const QrScan = () => {
             {scannedCodes.map((code, i) => (
               <Button
                 className={classes.button}
-                key={`qr-${i}`}
+                key={code}
                 variant="contained"
                 color={code ? 'success' : 'error'}
                 disableRipple

--- a/src/utils/qrHelpers.js
+++ b/src/utils/qrHelpers.js
@@ -1,15 +1,17 @@
 import { Base64 } from 'js-base64';
 import pako from 'pako';
 
-const getJws = (qrString) => {
-  const sliceIndex = qrString.lastIndexOf('/');
-  const rawPayload = qrString.slice(sliceIndex + 1);
-  const encodingChars = rawPayload.match(/\d\d/g);
-  return encodingChars.map((charPair) => String.fromCharCode(+charPair + 45)).join('');
-};
+const getJws = (qrCodes) => (
+  qrCodes.map((c) => {
+    const sliceIndex = c.lastIndexOf('/');
+    const rawPayload = c.slice(sliceIndex + 1);
+    const encodingChars = rawPayload.match(/\d\d/g);
+    return encodingChars.map((charPair) => String.fromCharCode(+charPair + 45)).join('');
+  }).join('')
+);
 
-const getPayload = (qrString) => {
-  const jwsString = getJws(qrString)
+const getPayload = (qrCodes) => {
+  const jwsString = getJws(qrCodes);
   const dataString = jwsString.split('.')[1];
   const decodedPayload = Base64.toUint8Array(dataString);
   const inflatedPayload = pako.inflateRaw(decodedPayload);
@@ -53,15 +55,15 @@ const extractPatientData = (card) => {
   return { name, dateOfBirth, immunizations };
 };
 
-const getPatientData = (qrCode) => {
-  if (!qrCode) { return null; }
-  const decodedQr = getPayload(qrCode);
+const getPatientData = (qrCodes) => {
+  if (!qrCodes || qrCodes.length === 0) { return null; }
+  const decodedQr = getPayload(qrCodes);
   return extractPatientData(decodedQr);
 };
 
-const getIssuer = (qrCode) => {
-  if (!qrCode) { return null; }
-  const payload = JSON.parse(getPayload(qrCode));
+const getIssuer = (qrCodes) => {
+  if (!qrCodes || qrCodes.length === 0) { return null; }
+  const payload = JSON.parse(getPayload(qrCodes));
   return payload.iss;
 };
 


### PR DESCRIPTION
- Allow scanning of multiple QR codes
    - Automatically detects how many codes need to be scanned based on prefix. `shc:/x/count`
- Added indicators to let user know which remaining QR codes need to be scanned.
![image](https://user-images.githubusercontent.com/6588796/139680900-5cfe5ef1-0187-4cc9-a321-6312dc3d694c.png)


