### PR TITLE
fix camera preview sizing

### DIFF
--- a/src/components/QrScan/QrScan.js
+++ b/src/components/QrScan/QrScan.js
@@ -69,9 +69,10 @@ const useStyles = makeStyles((theme) => ({
     zIndex: '2',
   },
   qrScanner: {
-    objectFit: 'contain',
+    objectFit: 'cover',
     position: 'absolute',
     width: '90%',
+    height: '90%',
     zIndex: '1',
     '& section': {
       position: 'unset !important',


### PR DESCRIPTION
Fix camera preview window size, set default to front facing camera. Tested in browser and on Android device. 