### PR TITLE
DVCI-299: Add Google Analytics

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
 INPUT_CQL=./cql
 OUTPUT_ELM=./src/output-elm
+REACT_APP_MEASUREMENT_ID=G-JK8FGR8HVG

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ node ./cql/SupportingData.js '/path/to/CDC/Version x.xx - 508/XML/AntigenSupport
 
 Will need to be updated with each CDSi release. Primary vaccine series number of doses are defined separately in src/supporting-data/AncilarySupportingData-{antigen}.json
 
+## Analytics
+
+The deployed version of the SMART Health Card Verifier at https://dvci.github.io/shc-web-verifier uses Google Analytics to track usage. This is done in a privacy-preserving way, and does not involve cookies. If you would like to remove or add your own tracking ID for local use, you may modify the `REACT_APP_MEASUREMENT_ID` environment variable in `.env`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/dvci/shc-web-verifier. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/dvci/shc-web-verifier/blob/main/CODE_OF_CONDUCT.md).

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JK8FGR8HVG"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_MEASUREMENT_ID%"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
@@ -53,6 +53,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div>"%REACT_APP_MEASUREMENT_ID%"</div>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
       });
       gtag('config', '%REACT_APP_MEASUREMENT_ID%');
     </script>
+    <!-- End Google Analytics -->
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <!--<meta name="viewport" content="width=device-width, initial-scale=1" />-->

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,10 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
+      gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        'analytics_storage': 'denied'
+      });
       gtag('config', 'G-JK8FGR8HVG');
     </script>
     <meta charset="utf-8" />

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
         'ad_storage': 'denied',
         'analytics_storage': 'denied'
       });
-      gtag('config', 'G-JK8FGR8HVG');
+      gtag('config', '%REACT_APP_MEASUREMENT_ID%');
     </script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JK8FGR8HVG"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-JK8FGR8HVG');
+    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <!--<meta name="viewport" content="width=device-width, initial-scale=1" />-->

--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,6 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div>"%REACT_APP_MEASUREMENT_ID%"</div>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -73,11 +73,7 @@
       },
       {
         "header": "INFORMATION COLLECTED FROM WEB TRAFFIC REPORTING TOOLS",
-        "content": "When a GitHub Pages site is visited, the visitor's IP address is logged and stored for security purposes, regardless of whether the visitor has signed into GitHub or not. For more information about GitHub's security practices, see <a target=\"top\" href=\"https://docs.github.com/en/github/site-policy/github-privacy-statement\" class=\"dotcom-only\">GitHub Privacy Statement</a>."
-      },
-      {
-        "header": "WEB TRACKING SERVICES",
-        "content": "This application sends web beacons to Google Analytics for measurement services when an individual visits the site. We do not store any cookies, nor do we share personal information with Google nor any third-party provider."
+        "content": "When a GitHub Pages site is visited, the visitor's IP address is logged and stored for security purposes, regardless of whether the visitor has signed into GitHub or not. For more information about GitHub's security practices, see <a target=\"top\" href=\"https://docs.github.com/en/github/site-policy/github-privacy-statement\" class=\"dotcom-only\">GitHub Privacy Statement</a>. </br>This application sends web beacons to Google Analytics for measurement services when an individual visits the site. We do not store any cookies, nor do we share personal information with Google nor any third-party provider."
       },
       {
         "header": "COOKIES",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -76,6 +76,10 @@
         "content": "When a GitHub Pages site is visited, the visitor's IP address is logged and stored for security purposes, regardless of whether the visitor has signed into GitHub or not. For more information about GitHub's security practices, see <a target=\"top\" href=\"https://docs.github.com/en/github/site-policy/github-privacy-statement\" class=\"dotcom-only\">GitHub Privacy Statement</a>."
       },
       {
+        "header": "WEB TRACKING SERVICES",
+        "content": "This application sends web beacons to Google Analytics for measurement services when an individual visits the site. We do not store any cookies, nor do we share personal information with Google nor any third-party provider."
+      },
+      {
         "header": "COOKIES",
         "content": "“Cookies” are data that may be sent to your web browser and stored on your computer. This Site does not use cookies."
       },


### PR DESCRIPTION
In order to track site visits using Google Analytics, we need to add a site tag to our application.

See https://developers.google.com/analytics/devguides/collection/gtagjs for more info.