### PR TITLE
DVCI-308: Reformat hidden DOB

### DIFF
--- a/src/components/VaccineCard/VaccineCard.js
+++ b/src/components/VaccineCard/VaccineCard.js
@@ -133,7 +133,7 @@ const VaccineCard = () => {
                 {patientData.dateOfBirth}
               </Typography>
               <Typography className={styles.dateOfBirth} hidden={showDateOfBirth}>
-                {'**/**/****'}
+                {'xxxx-xx-xx'}
               </Typography>
               <IconButton
                 className={styles.eyeOutline}


### PR DESCRIPTION
This PR changes the format for how the date of birth is hidden in order to match how the date of birth is displayed when it is visible: `0000-00-00.` 
This also confirms that wen you toggle one card DOB, the other cards are not affected. To test, load two cards and toggle the date of births individually. 

### **Previously:** 
![DOBFormatOld](https://user-images.githubusercontent.com/107197502/175116204-2e6c981d-dbe1-41de-bf52-4eb359c15dec.PNG)
### **Now:**
![DOBStyling](https://user-images.githubusercontent.com/107197502/175115003-d4d361de-6013-4530-9796-f6431728e4da.PNG)
## Alternatively
![DOBFormatOld](https://user-images.githubusercontent.com/107197502/175115260-1b4ec050-d904-4814-9f36-970a8f807dcf.PNG)
The asterisks could be kept which makes it less eye-catching, but it makes the dashes look like underscores and it makes toggling less neat as the characters for hidden and shown are not the same width (whereas the x example has almost identical widths).