### PR TITLE
DVCI-310 Windows Incompatibility 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,7 @@
     "comma-dangle": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prop-types": "off",
-    "semi": "off",
-    "linebreak-style": [0 ,"error", "windows"]
+    "semi": "off"
   },
   "settings": {
     "import/resolver": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
     "comma-dangle": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prop-types": "off",
-    "semi": "off"
+    "semi": "off",
+    "linebreak-style": [0 ,"error", "windows"]
   },
   "settings": {
     "import/resolver": {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 Windows users: You may require these commands when starting the verifier from gitbash\
 `set BUILD_PATH="./www"`\
-`yarn react-scripts start`
+`yarn react-scripts start`\
+If you encounter the error message: "Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style"\
+run `npm run lint -- --fix` to fix the eol styling caused by Windows using CRLf instead of LF
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ In the project directory, you can run:
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
+Windows users: You may require these commands when starting the verifier from gitbash\
+`set BUILD_PATH="./www"`\
+`yarn react-scripts start`
+
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eject": "react-scripts eject",
     "predeploy": "yarn run build",
     "deploy": "gh-pages -d www",
-    "lint": "eslint './src/**/*.{js,jsx,ts,tsx}'",
+    "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint './src/**/*.{js,jsx,ts,tsx}' --fix",
     "prettier": "prettier --check \"**/*.{js,ts,tsx}\"",
     "prettier:fix": "prettier --write \"**/*.{js,ts,tsx}\""

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "predeploy": "yarn run build",
     "deploy": "gh-pages -d www",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
-    "lint_fix": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" --fix",
+    "lint-fix": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" --fix",
     "prettier": "prettier --check \"**/*.{js,ts,tsx}\"",
-    "prettier:fix": "prettier --write \"**/*.{js,ts,tsx}\""
+    "prettier-fix": "prettier --write \"**/*.{js,ts,tsx}\""
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "eject": "react-scripts eject",
     "predeploy": "yarn run build",
     "deploy": "gh-pages -d www",
-    "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
-    "lint:fix": "eslint './src/**/*.{js,jsx,ts,tsx}' --fix",
+    "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
+    "lint_fix": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" --fix",
     "prettier": "prettier --check \"**/*.{js,ts,tsx}\"",
     "prettier:fix": "prettier --write \"**/*.{js,ts,tsx}\""
   },


### PR DESCRIPTION
This PR changes a few things in order to smooth out use on a Windows machine.
1. Added a linebreak-style to prevent the console from being flooded with a linebreak-style error message
<img src="https://user-images.githubusercontent.com/107197502/176261286-620898d9-d656-4725-85f1-1814f3bb7f9a.PNG" width="400" /> 
<img src="https://user-images.githubusercontent.com/107197502/176261316-4f85fb22-e9bf-466c-80b7-afff8cae93b1.PNG" width="400" />

2. Added a few lines of documentation in the README for starting the verifier on Windows with gitbash
3. Changed a line related to lint that allows Windows users to run `npm run lint` in gitbash, previously an error about no files matching the pattern would occur

This needs to be tested on a non-Windows machine to make sure that the changes enabling Windows usage do not interfere with other operating systems. 
### To test:
- Run the verifier as usual, scan a few cards and make sure that no unexpected errors or changes in behavior occur
- Run `npm run lint` to make sure that linting tests work as expected
- Run `npm run lint_fix` formerly being `npm run lint:fix` to make sure that it runs as expected