### PR TITLE
DVCI-303: Update QrScan to remove camera console errors

### DIFF
--- a/src/components/QrScan/QrScan.js
+++ b/src/components/QrScan/QrScan.js
@@ -159,7 +159,6 @@ const QrScan = () => {
       qrScan = new QrScanner(
         videoElement,
         (results) => {
-          // runningQrScanner.current.stop();
           setScannedData(results.data);
         },
         {
@@ -249,6 +248,10 @@ const QrScan = () => {
       } catch (e) {
         handleError();
       }
+    }
+
+    return () => {
+      setScannedData('');
     }
   }, [scannedData, handleError, history, location, setQrCodes, resetQrCodes, qrCodes]);
 


### PR DESCRIPTION
# Summary
This PR addresses the React warnings that are being thrown for non-exhaustive dependency arrays in the QrScan component. Also addresses the DOMException for the play() request being interrupted by a new load/pause request.

## Background
The `setCamera()` function from the [qr-scanner library ](https://github.com/nimiq/qr-scanner) restarts the video stream when it updates the camera device that is in use. This causes the [uncaught DOMException that the play() request was interrupted](https://developer.chrome.com/blog/play-request-was-interrupted/) (the play() request comes from QrScanner.start(), while the pause() comes from QrScanner.setCamera()). While the library has some async handling for the `start()` and `stop()`, we still run into race conditions because of the state updates and the lack of async handling for `video.pause()`. 

According to the React documentation, the `useEffect` hook’s dependency array should be exhaustive, which requires adding the `cameraDeviceId` to the dependency array. However, this causes `createQrScanner()` to be called multiple times, slowing performance and causing the `play()` interruption warnings to persist. On iOS, we do need to call `createQrScanner()` when the camera switches, as `setCamera()` does not actually restart the video stream on iOS.

## Code Changes
* Call `setCamera()` from `switchCamera()` to avoid calling it when we initially set the `cameraDeviceId` after getting the user media (otherwise will restart the video stream and interrupt the `play()` request that has not yet resolved)
* Add new `useEffect()` to clean up the `runningQrScanner`, stopping the scanner (if called from another `useEffect`, the scanner will stop prematurely, either when we switch the `cameraDeviceId` or when we scan multiple QRs)
* Wrap `qrScan.start()` into a promise to avoid race conditions with setting the `cameraDeviceId`
* Add a condition to create a new QrScanner instance only if we are creating one for the first time or if the platform is iOS

## Testing Guidance
Test the following and check that functionality and performance are unchanged, and that no React warnings appear in the console:
* Scan single QR on browser
* Scan multiple SHC’s for same patient on browser
* Scan multi-QR SHC on browser
* Scan for Android, checking that the camera still switches
* Scan for iOS, checking that the camera still switches