### PR TITLE
Order immunizations by occurrenceDateTime

### DIFF
--- a/src/components/VaccineCard/VaccineCard.js
+++ b/src/components/VaccineCard/VaccineCard.js
@@ -71,6 +71,15 @@ const VaccineCard = () => {
     return tradenames[coding.code];
   };
 
+  const orderImmunizations = (immunizationsArray) => {
+    // sort immunizations in ascending order based on occurrence date
+    const sortedAsc = immunizationsArray.sort(
+      (imm1, imm2) => new Date(imm1.resource.occurrenceDateTime)
+       - new Date(imm2.resource.occurrenceDateTime),
+    );
+    return sortedAsc;
+  };
+
   const HealthCardVaccination = ({ immunization }) => (
     <Box className={[styles.flexCol, styles.vaccinationRoot].join(' ')}>
       <Box className={styles.divider}>
@@ -154,7 +163,7 @@ const VaccineCard = () => {
               </Typography>
             </Box>
             <List className={styles.vaccinationRecordList}>
-              {patientData.immunizations.map((item) => (
+              {orderImmunizations(patientData.immunizations).map((item) => (
                 <div key={item.fullUrl}>
                   <ListItem className={styles.vaccinationRecordListItem}>
                     <HealthCardVaccination immunization={item.resource} />


### PR DESCRIPTION
Currently, the vaccines get displayed in the order that they appear in the FHIR Bundle. The helper function created in this PR sorts the immunizations in the patient bundle by their `occurrenceDateTime` in ascending order before rendering the content of the immunizations on the page.