### PR TITLE
Update Clicky script to open pull request

### DIFF
--- a/.github/workflows/clicky-workflow.yml
+++ b/.github/workflows/clicky-workflow.yml
@@ -28,10 +28,13 @@ jobs:
         run: |
             python runClickyScript.py
       - 
-        name: "Push changes"
-        run: |-
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git add .
-            git commit -m "Update Clicky Analytics"
-            git push
+        name: "Create pull request"
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update Clicky visitor data
+          title: Update Clicky visitor data
+          body: Workflow auto-generated PR
+          branch: update-clicky-data
+          branch-suffix: timestamp
+          reviewers: sarahmcdougall


### PR DESCRIPTION
Currently, the Clicky workflow tries to push from main, which is rejected since at least one reviewer approval is required. This PR changes the workflow so that it instead creates a pull request when the script runs successfully. Open to alternative approaches for this, but I think it would be nice to view a pull request each week in order to see how the visitor data changes each week.